### PR TITLE
fix: update github actions script to accommodate new make build structure

### DIFF
--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -15,7 +15,7 @@ jobs:
       # Setup python + clone repos
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - uses: actions/checkout@v2
       - name: Copy to ~/.whale
         run: |
@@ -32,7 +32,7 @@ jobs:
           echo ${BIGQUERY_JSON} > ~/.whale/credentials.json
           make python
           source ~/.whale/libexec/env/bin/activate
-          python ~/.whale/libexec/build_script.py
+          python3 ~/.whale/libexec/build_script.py
 
       # Push to git
       - name: push-to-git

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,32 +1,37 @@
-name: Whale ETL
+name: Whale Runner
 on:
   schedule:
-   - cron: "0 */12 * * *"
+   - cron: "*/5 * * * *"
 
 jobs:
   run-etl:
     runs-on: ubuntu-latest
     steps:
+
+      # Setup python + clone repos
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - uses: actions/checkout@v2
-      - name: install
-        run: |
-          cp -r . ~/.whale/
+        with:
+          path: ~/.whale
       - uses: actions/checkout@v2
         with:
           repository: dataframehq/whale
           path: whale
+
+      # Scrape from warehouse
       - name: etl
         working-directory: ./whale
         run: |
           echo ${BIGQUERY_JSON} > ~/.whale/credentials.json
           make python
-          mkdir ~/.whale/logs
-          source ./build/env/bin/activate
-          python ./build/build_script.py
-          cd ~/.whale
+          source ~/.whale/libexec/env/bin/activate
+          python ~/.whale/libexec/build_script.py
+
+      # Push to git
+      - name: push-to-git
+        working-directory: ~/.whale
           git config user.name 'GHA Runner'
           git config user.email '<your_username>@users.noreply.github.com'
           git add metadata manifests metrics

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -15,7 +15,7 @@ jobs:
       # Setup python + clone repos
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.7'
       - uses: actions/checkout@v2
       - name: Copy to ~/.whale
         run: |

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -29,10 +29,9 @@ jobs:
       - name: etl
         working-directory: ./whale
         run: |
-          echo ${BIGQUERY_JSON} > ~/.whale/credentials.json
+          echo '${{ secrets.BIGQUERY_JSON }}' > ~/.whale/credentials.json
           make python
           source ~/.whale/libexec/env/bin/activate
-          pip3 install requests
           python3 ~/.whale/libexec/build_script.py
 
       # Push to git
@@ -44,5 +43,3 @@ jobs:
           git add metadata manifests metrics
           git commit -m "Automated push." || echo "No changes to commit"
           git push
-        env:
-          BIGQUERY_JSON: ${{ secrets.BIGQUERY_JSON }}

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,11 +1,7 @@
 name: Whale Runner
 on:
-  push:
-    branches:
-      - rsyi/modify-gha
-#on:
-#  schedule:
-#   - cron: "*/5 * * * *"
+  schedule:
+   - cron: "0 */6 * * *"
 
 jobs:
   run-etl:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -32,6 +32,7 @@ jobs:
       # Push to git
       - name: push-to-git
         working-directory: ~/.whale
+        run: |
           git config user.name 'GHA Runner'
           git config user.email '<your_username>@users.noreply.github.com'
           git add metadata manifests metrics

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -32,9 +32,7 @@ jobs:
           echo ${BIGQUERY_JSON} > ~/.whale/credentials.json
           make python
           source ~/.whale/libexec/env/bin/activate
-          pip3 install google-api-python-client
-          pip3 install google-auth-httplib2
-          pip3 install google-auth-oauthlib
+          pip3 install requests
           python3 ~/.whale/libexec/build_script.py
 
       # Push to git

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,7 +1,11 @@
 name: Whale Runner
 on:
-  schedule:
-   - cron: "*/5 * * * *"
+  push:
+    branches:
+      - rsyi/modify-gha
+#on:
+#  schedule:
+#   - cron: "*/5 * * * *"
 
 jobs:
   run-etl:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Copy to ~/.whale
         run: |
-          cp -r . ~/.whale
+          cp -r . ~/.whale/
       - uses: actions/checkout@v2
         with:
           repository: dataframehq/whale
@@ -32,6 +32,9 @@ jobs:
           echo ${BIGQUERY_JSON} > ~/.whale/credentials.json
           make python
           source ~/.whale/libexec/env/bin/activate
+          pip3 install google-api-python-client
+          pip3 install google-auth-httplib2
+          pip3 install google-auth-oauthlib
           python3 ~/.whale/libexec/build_script.py
 
       # Push to git

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -17,8 +17,9 @@ jobs:
         with:
           python-version: '3.8'
       - uses: actions/checkout@v2
-        with:
-          path: ~/.whale
+      - name: Copy to ~/.whale
+        run: |
+          cp -r . ~/.whale
       - uses: actions/checkout@v2
         with:
           repository: dataframehq/whale


### PR DESCRIPTION
Due to changes in how the makefile build directory is structured (turns out virtual environments aren't very portable, so we installing the virtual env directly into the `~/.whale/libexec/env` path instead), we adjust the code to source from the final destination in libexec instead (rather than the `./build` directory, which is now deprecated).

This PR also includes a few QOL improvements:
* Add comments and split up the git push step for easier grokking.
* Migrate to python 3.8 (which is what we're testing on, anyways).
* Directly invoke the github secret w/the BQ credentials, rather than specifying a env variable and referencing that indirectly.

These changes will be reflected in the [docs](docs.whale.cx) as well, in the sample github actions code.